### PR TITLE
Add Jpsi to ee channel (input data are now placeholders)

### DIFF
--- a/analysis/databases/general.yaml
+++ b/analysis/databases/general.yaml
@@ -4,11 +4,13 @@ latexparticle:
   Omega_cc: "#Omega_{cc}"
   Omega_ccc: "#Omega_{ccc}"
   X3872: "X(3872)"
-
+  Jpsitoee: "J/#psi #rightarrow e^{+}e^{-}"
 text_string:
   pp14p0: "pp #sqrt{s}= 14 TeV"
   absy3p0: "|y| < 3.0"
+  absy2p0: "|y| < 2.0"
   Pyhia8mode2: "Pythia 8, mode = 2"
+  Pyhia8monash: "Pythia 8, monash tune"
 statistics:
   PbPb2p76: 
     sigmaAA_b: 7.8 #FIXME these are copied from 5.52 TeV 
@@ -30,6 +32,8 @@ statistics:
     lumiAA_monthi_invnb: 3000000
 
 branchingratio:
+  Jpsitoee:
+    central: 0.0594
   Lambda_c:
     central: 0.0628
   Xi_cc: #https://arxiv.org/abs/1703.09086

--- a/analysis/databases/significance.yaml
+++ b/analysis/databases/significance.yaml
@@ -11,3 +11,16 @@ Lambda_c:
       theoryfile: ../InputsTheory/Lambda_c_ptdep_Pyhia8mode2_pp14p0_absy3p0.root
       histoyield: hLcpt_N
       histoyield_norm: hLcpt_N
+Jpsitoee:
+  pp14p0:
+    absy2p0:
+      ymin: 40
+      ymax: 10000000
+      binning: [0.,1.,2.,4.,6.,8.,10.]
+      efffile: ../InputsExp/Jpsi_ptdep_pp14p0_absy2p0_scenario3/efficiencies.root #this is temporarily the Lc files
+      histoeff: eff
+      bkgfile: ../InputsExp/Jpsi_ptdep_pp14p0_absy2p0_scenario3/bkgperevent.root #this is temporarily the Lc files
+      histobkg: hbkg_fromsidebands
+      theoryfile: ../InputsTheory/Jpsi_ptdep_Pyhia8monash_pp14p0_absy2p0.root #this is temporarely the Lc file
+      histoyield: hLcpt_N #to be replaced with the name of the jpsi th histogram
+      histoyield_norm: hLcpt_N #to be replaced with the name of the jpsi th histogram

--- a/analysis/databases/theory_yields.yaml
+++ b/analysis/databases/theory_yields.yaml
@@ -65,6 +65,11 @@ Pyhia8mode2:
   pp14p0:
     absy3p0:
       Lambda_c: 1
+
+Pyhia8monash:
+  pp14p0:
+    absy2p0:
+      Jpsitoee: 1
 comparison_models_AA:
   pt_binning:
     Lambda_c: [0,1,2,3,4,5,6,7,8,9,10]

--- a/analysis/significance.py
+++ b/analysis/significance.py
@@ -47,10 +47,11 @@ def analysis(hadron="Lambda_c", collision="pp14p0", yrange="absy3p0", \
     nevt = sigma_aa_b * lumiaa_monthi_invnb * 1e9
     #nevt = 2.*1e9
     bratio = paramgen["branchingratio"][hadron][brmode]
+    decaychannel = paramgen["latexparticle"][hadron]
 
     yieldmid = paramyields[model][collision][yrange][hadron]
     text = '%s, N_{ev} = %.0f 10^{12}' % (textmodel, nevt/1e12)
-    text_a = '#Lambda_{c} #rightarrow pK#pi, %s, BR=%.2f%%' % (textrapid, bratio*100)
+    text_a = '%s, %s, BR=%.2f%%' % (decaychannel, textrapid, bratio*100)
     text_b = 'ALICE3 projection, with IRIS, no PID, %s' % textcollision
     fileeff = TFile(nfileeff)
     histoeff = fileeff.Get(nhistoeff)
@@ -159,4 +160,5 @@ def analysis(hadron="Lambda_c", collision="pp14p0", yrange="absy3p0", \
     histoyieldth.Write()
     histosignf.Write()
     histodndptth.Write()
-analysis("Lambda_c")
+analysis("Lambda_c", "pp14p0", "absy3p0", "central", "Pyhia8mode2", 1)
+analysis("Jpsitoee", "pp14p0", "absy2p0", "central", "Pyhia8monash", 1)


### PR DESCRIPTION
- Currently all is set but the input files are still the ones from the Lc analysis
- in databases/significance.yaml we will have to replace the root files efficiencies.root, bkgperevent.root, Jpsi_ptdep_Pyhia8monash_pp14p0_absy2p0.root with the real ones. Also the name of the histogram in the theory curve will need to be updated histoyield, histoyield_norm.